### PR TITLE
Add boost to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Native desktop client for slack.com
 
 ## Dependencies
+- boost
 - jsoncpp
 - gtkmm 3
 - libsoup


### PR DESCRIPTION
boost is a compile-time dependency that was ommitted. Since the app cannot compile without it, it should be added.